### PR TITLE
CAN Hotfix

### DIFF
--- a/Firmware/Drivers/Inc/AmperesADC.h
+++ b/Firmware/Drivers/Inc/AmperesADC.h
@@ -59,7 +59,7 @@ AmperesStatus_t Amperes_StartADC(bool clearQueue);
 /**
  * @brief Get adc reading from ADC queue and convert to current (mA);
  *        expected range is -50,000 to +82,00 mA.
- * @param message Pointer to AmperesMsg_t struct to hold adc and current values
+ * @param message Pointer to bps_pack_current_t struct to hold adc and current values
  * @param ticksToWait Number of ticks to wait on queue: 0 for non-blocking, portMAX_DELAY for blocking
  * @retval AmperesStatus_t
  * @n 
@@ -67,4 +67,4 @@ AmperesStatus_t Amperes_StartADC(bool clearQueue);
  * @n
  * - AMPERES_ADC_READ_FAIL on fail
  */
-AmperesStatus_t Amperes_GetReading(AmperesMsg_t *message, TickType_t ticksToWait);
+AmperesStatus_t Amperes_GetReading(bps_pack_current_t *message, TickType_t ticksToWait);

--- a/Firmware/Drivers/Inc/AmperesADC.h
+++ b/Firmware/Drivers/Inc/AmperesADC.h
@@ -17,8 +17,9 @@ extern QueueHandle_t adc_queue;
  * Calibration and conversion
  * ===============================================================
  * - ADC_xA is the ADC value at different current values.
- * - Scale constant is just the slope scaled by 1000: 
- *      (mA1 - mA2) / (adc1 - adc2) * 1000
+ * - Scale constant (uA / adc count) is the slope: 
+ *      ((mA1 - mA2) / (adc1 - adc2)) * 1000
+ * - Remember to divide by 1000 to scale back to mA
  */
 #define ADC_0A          1527
 #define ADC_PLUS_10A    1828

--- a/Firmware/Drivers/Inc/AmperesCAN.h
+++ b/Firmware/Drivers/Inc/AmperesCAN.h
@@ -14,17 +14,6 @@
 #endif
 extern QueueHandle_t can_tx_queue;
 
-/**
- * @brief Structure to hold Amperes data
- * @n 
- * - int32_t current_data
- * @n 
- * - uint16_t adc_voltage
- */
-typedef struct AmperesMsg {
-    int32_t current_data;   // signed, 32 bit
-    uint16_t adc_voltage;   // unsigned, 12 bit
-} AmperesMsg_t;
 
 /**
  * @brief Initialize CAN filter and hardware
@@ -48,7 +37,7 @@ AmperesStatus_t Amperes_CAN_Start();
 
 /**
  * @brief Send Amperes data over BPS_CAN
- * @param data Pointer to Amperes message struct
+ * @param data Pointer to bps_pack_current_t message struct
  * @param ticksToWait Number of ticks to wait on send: 0 for non-blocking, portMAX_DELAY for blocking
  * @retval AmperesStatus_t
  * @n 
@@ -56,4 +45,4 @@ AmperesStatus_t Amperes_CAN_Start();
  * @n
  * - AMPERES_CAN_SEND_FAIL on fail
  */
-AmperesStatus_t Amperes_SendCAN(AmperesMsg_t *data, TickType_t ticksToWait);
+AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait);

--- a/Firmware/Drivers/Inc/AmperesCAN.h
+++ b/Firmware/Drivers/Inc/AmperesCAN.h
@@ -14,6 +14,11 @@
 #endif
 extern QueueHandle_t can_tx_queue;
 
+/**
+ * NOTE: Amperes CAN message is held in bps_pack_current_t
+ * - I'm using Main_Battery_Current_RawV internally to hold the ADC value;
+ *   it gets converted to actual voltage value inside Amperes_SendCAN
+ */
 
 /**
  * @brief Initialize CAN filter and hardware

--- a/Firmware/Drivers/Inc/AmperesCAN.h
+++ b/Firmware/Drivers/Inc/AmperesCAN.h
@@ -25,8 +25,8 @@ extern QueueHandle_t can_tx_queue;
  * - little endian, see bps_pack_current_t struct. 
  * - handle sign extension for 24b -> int32_t
  */
-#define CURRENT_CONV(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
-#define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
+#define AMPERES_UNPACK_CURRENT_mA(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
+#define AMPERES_UNPACK_RAW_mV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
 
 /**
  * @brief Initialize CAN filter and hardware

--- a/Firmware/Drivers/Inc/AmperesCAN.h
+++ b/Firmware/Drivers/Inc/AmperesCAN.h
@@ -21,6 +21,14 @@ extern QueueHandle_t can_tx_queue;
  */
 
 /**
+ * Macros to reconstruct values
+ * - little endian, see bps_pack_current_t struct. 
+ * - handle sign extension for 24b -> int32_t
+ */
+#define CURRENT_CONV(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
+#define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
+
+/**
  * @brief Initialize CAN filter and hardware
  * @retval AmperesStatus_t
  * @n 

--- a/Firmware/Drivers/Inc/AmperesConfig.h
+++ b/Firmware/Drivers/Inc/AmperesConfig.h
@@ -60,7 +60,7 @@ typedef enum AmperesStatus {
  *  CAN (CAN1)
  * ================================================================ */
 
-#define AMPERES_MSG_DLC     6
+#define AMPERES_MSG_DLC     CAN_DLC_BPS_PACK_CURRENT
 #define AMPERES_MSG_ID      CAN_ID_BPS_PACK_CURRENT
 #define AMPERES_CAN_PORT    GPIOB
 #define AMPERES_RX_PIN      GPIO_PIN_8

--- a/Firmware/Drivers/Inc/BPSCAN_can_msgs.h
+++ b/Firmware/Drivers/Inc/BPSCAN_can_msgs.h
@@ -4,131 +4,157 @@
 
 /* ================= CAN ID Macros ================= */
 
-#define CAN_ID_BPS_STATUS 0x1
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_0 0x2
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_1 0x3
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_2 0x4
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_3 0x5
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_4 0x6
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_5 0x7
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_6 0x8
-#define CAN_ID_BPS_VOLTAGE_TEMPERATURE_7 0x9
+#define CAN_ID_BPS_VOLTAGE_ARR_0 0x2
+#define CAN_ID_BPS_VOLTAGE_ARR_1 0x3
+#define CAN_ID_BPS_VOLTAGE_ARR_2 0x4
+#define CAN_ID_BPS_VOLTAGE_ARR_3 0x5
+#define CAN_ID_BPS_VOLTAGE_ARR_4 0x6
+#define CAN_ID_BPS_VOLTAGE_ARR_5 0x7
+#define CAN_ID_BPS_VOLTAGE_ARR_6 0x8
+#define CAN_ID_BPS_VOLTAGE_ARR_7 0x9
 #define CAN_ID_BPS_PACK_CURRENT 0xA
+#define CAN_ID_BPS_TEMPERATURE_ARR_0 0x10
+#define CAN_ID_BPS_TEMPERATURE_ARR_1 0x11
+#define CAN_ID_BPS_TEMPERATURE_ARR_2 0x12
+#define CAN_ID_BPS_TEMPERATURE_ARR_3 0x13
+#define CAN_ID_BPS_TEMPERATURE_ARR_4 0x14
+#define CAN_ID_BPS_TEMPERATURE_ARR_5 0x15
+#define CAN_ID_BPS_TEMPERATURE_ARR_6 0x16
+#define CAN_ID_BPS_TEMPERATURE_ARR_7 0x17
 #define CAN_ID_BPS_PRECHARGE_VOLTAGES 0x20
 
+/* ================= CAN Length Macros ================= */
 
-/* ================= Value Table Enums ================= */
+#define CAN_DLC_BPS_VOLTAGE_ARR_0 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_1 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_2 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_3 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_4 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_5 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_6 4
+#define CAN_DLC_BPS_VOLTAGE_ARR_7 4
+#define CAN_DLC_BPS_PACK_CURRENT 5
+#define CAN_DLC_BPS_TEMPERATURE_ARR_0 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_1 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_2 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_3 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_4 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_5 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_6 7
+#define CAN_DLC_BPS_TEMPERATURE_ARR_7 7
+#define CAN_DLC_BPS_PRECHARGE_VOLTAGES 6
 
-typedef enum {
-    BPS_STATUS_BPS_FAULT_DISCHARGING_OVERCURRENT = 16,
-    BPS_STATUS_BPS_FAULT_CHARGING_OVERCURRENT = 15,
-    BPS_STATUS_BPS_FAULT_ESTOP_3 = 14,
-    BPS_STATUS_BPS_FAULT_ESTOP_2 = 13,
-    BPS_STATUS_BPS_FAULT_ESTOP_1 = 12,
-    BPS_STATUS_BPS_FAULT_ARRAY_PCHG_CONTACTOR_SENSE = 11,
-    BPS_STATUS_BPS_FAULT_ARRAY_CONTACTOR_SENSE = 10,
-    BPS_STATUS_BPS_FAULT_HV_MINUS_CONTACTOR_SENSE = 9,
-    BPS_STATUS_BPS_FAULT_HV_PLUS_CONTACTOR_SENSE = 8,
-    BPS_STATUS_BPS_FAULT_WATCHDOG = 7,
-    BPS_STATUS_BPS_FAULT_ARRAY_PRECHARGE_TIMEOUT = 6,
-    BPS_STATUS_BPS_FAULT_ELCON = 5,
-    BPS_STATUS_BPS_FAULT_OVERTEMPERATURE = 4,
-    BPS_STATUS_BPS_FAULT_REGEN = 3,
-    BPS_STATUS_BPS_FAULT_UNDERVOLTAGE = 2,
-    BPS_STATUS_BPS_FAULT_OVERVOLTAGE = 1,
-    BPS_STATUS_BPS_FAULT_NO_FAULT = 0,
-} bps_status_bps_fault_e;
 
 /* ================= Message Structs ================= */
 
 typedef struct {
-    uint8_t BPS_Fault;
-    uint8_t BPS_Charge_OK;
-    uint8_t BPS_Regen_OK;
-    uint8_t HV_Plus_Contactor_State;
-    uint8_t HV_Minus_Contactor_State;
-    uint8_t Array_Contactor_State;
-    uint8_t Array_Precharge_Contactor_State;
-    uint32_t Main_Battery_Voltage;
-    int16_t Main_Battery_Avg_Temperature;
-} bps_status_t;
+    uint8_t BPS_Tap_idx;
+    uint16_t BPS_Voltage_Tap_Data;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_0_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_0_t;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_1_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_1_t;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_2_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_2_t;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_3_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_3_t;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_4_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_4_t;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_5_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_5_t;
+    uint8_t BPS_VoltTemp_BQ_Fault;
+} bps_voltage_arr_6_t;
 
 typedef struct {
-    uint8_t BPS_Tap_ID;
-    uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
+    uint8_t BPS_Tap_idx;
     uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_6_t;
-
-typedef struct {
-    uint8_t BPS_Tap_ID;
     uint8_t BPS_VoltTemp_BQ_Fault;
-    uint8_t BPS_Temperature_Tap_Fault;
-    uint16_t BPS_Voltage_Tap_Data;
-    int16_t BPS_Temperature_Tap_Data;
-    uint16_t BPS_Temperature_Tap_RawV;
-} bps_voltage_temperature_7_t;
+} bps_voltage_arr_7_t;
 
 typedef struct {
     int32_t Main_Battery_Current;
     uint16_t Main_Battery_Current_RawV;
 } bps_pack_current_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_0_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_1_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_2_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_3_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_4_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_5_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_6_t;
+
+typedef struct {
+    uint8_t BPS_Tap_idx;
+    uint8_t BPS_Temperature_Tap_Fault;
+    int32_t BPS_Temperature_Tap_Data;
+    uint16_t BPS_Temperature_Tap_RawV;
+} bps_temperature_arr_7_t;
 
 typedef struct {
     uint32_t Precharge_Battery_Voltage;

--- a/Firmware/Drivers/Src/AmperesADC.c
+++ b/Firmware/Drivers/Src/AmperesADC.c
@@ -98,11 +98,11 @@ AmperesStatus_t Amperes_StartADC(bool clearQueue) {
     return AMPERES_OK;
 }
 
-AmperesStatus_t Amperes_GetReading(AmperesMsg_t *message, TickType_t ticksToWait) {
+AmperesStatus_t Amperes_GetReading(bps_pack_current_t *message, TickType_t ticksToWait) {
     // Get ADC value from queue
-    if (xQueueReceive(adc_queue, &(message->adc_voltage), ticksToWait) != pdPASS) { 
+    if (xQueueReceive(adc_queue, &(message->Main_Battery_Current_RawV), ticksToWait) != pdPASS) { 
         return AMPERES_ADC_READ_FAIL;
     }
-    message->current_data = Amperes_ADCToCurrent(message->adc_voltage);
+    message->Main_Battery_Current = Amperes_ADCToCurrent(message->Main_Battery_Current_RawV);
     return AMPERES_OK;
 }

--- a/Firmware/Drivers/Src/AmperesCAN.c
+++ b/Firmware/Drivers/Src/AmperesCAN.c
@@ -1,4 +1,5 @@
 #include "AmperesCAN.h"
+#include <string.h>
 
 /** ================================================================
  *  Queue for CAN Message mirroring
@@ -113,14 +114,11 @@ AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait
     // Little Endian (LSB first): e.g. 0x123456 is stored as [56][34][12]
     uint8_t tx_data[AMPERES_MSG_DLC] = {0};
 
-    /* Current Data: int32_t */
-    tx_data[0] = (uint8_t) (data->Main_Battery_Current & 0xFF);
-    tx_data[1] = (uint8_t) ((data->Main_Battery_Current >> 8) & 0xFF);
-    tx_data[2] = (uint8_t) ((data->Main_Battery_Current >> 16) & 0xFF);
+    /* Current Data: int32_t into 24 bit field (little endian)*/
+    memcpy(tx_data, &data->Main_Battery_Current, 3);
 
-    /* Raw Voltage Value: uint16_t */
-    tx_data[3] = (uint8_t) (adc_to_voltage & 0xFF);
-    tx_data[4] = (uint8_t) ((adc_to_voltage >> 8) & 0xFF);
+    /* Raw Voltage Value: uint16_t into 16 bit field (little endian)*/
+    memcpy(tx_data+3, &adc_to_voltage, 2);
 
     // Send over CAN
     if (can_send(hcan1, &tx_header, tx_data, ticksToWait) != CAN_OK) {

--- a/Firmware/Drivers/Src/AmperesCAN.c
+++ b/Firmware/Drivers/Src/AmperesCAN.c
@@ -67,7 +67,7 @@ static bool MX_CAN_Init() {
     hcan1->Init.Mode = CAN_MODE_NORMAL;
     #endif
     hcan1->Init.TimeTriggeredMode = DISABLE;
-    hcan1->Init.AutoBusOff = DISABLE;
+    hcan1->Init.AutoBusOff = ENABLE;
     hcan1->Init.AutoWakeUp = DISABLE;
     hcan1->Init.AutoRetransmission = ENABLE;
     hcan1->Init.ReceiveFifoLocked = DISABLE;

--- a/Firmware/Drivers/Src/AmperesCAN.c
+++ b/Firmware/Drivers/Src/AmperesCAN.c
@@ -106,6 +106,9 @@ AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait
     tx_header.DLC = AMPERES_MSG_DLC;
     tx_header.TransmitGlobalTime = DISABLE;
 
+    // Convert ADC to voltage
+    uint16_t adc_to_voltage = ((uint32_t) data->Main_Battery_Current_RawV * 3300)/4095);
+
     // Split data into uint8 elements; reference bps_pack_current_t struct
     // Little Endian: LSB at index 0
     uint8_t tx_data[AMPERES_MSG_DLC] = {0};
@@ -115,9 +118,9 @@ AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait
     tx_data[1] = (uint8_t) ((data->Main_Battery_Current >> 8) & 0xFF);
     tx_data[2] = (uint8_t) ((data->Main_Battery_Current >> 16) & 0xFF);
 
-    /* Raw ADC Value: uint16_t */
-    tx_data[3] = (uint8_t) (data->Main_Battery_Current_RawV & 0xFF);
-    tx_data[4] = (uint8_t) ((data->Main_Battery_Current_RawV >> 8) & 0xFF);
+    /* Raw Voltage Value: uint16_t */
+    tx_data[3] = (uint8_t) (adc_to_voltage & 0xFF);
+    tx_data[4] = (uint8_t) ((adc_to_voltage >> 8) & 0xFF);
 
     // Send over CAN
     if (can_send(hcan1, &tx_header, tx_data, ticksToWait) != CAN_OK) {

--- a/Firmware/Drivers/Src/AmperesCAN.c
+++ b/Firmware/Drivers/Src/AmperesCAN.c
@@ -97,7 +97,7 @@ AmperesStatus_t Amperes_CAN_Start() {
     return AMPERES_OK;
 }
 
-AmperesStatus_t Amperes_SendCAN(AmperesMsg_t *data, TickType_t ticksToWait) {
+AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait) {
     // Create CAN payload
     CAN_TxHeaderTypeDef tx_header = {0};
     tx_header.StdId = AMPERES_MSG_ID;
@@ -106,20 +106,19 @@ AmperesStatus_t Amperes_SendCAN(AmperesMsg_t *data, TickType_t ticksToWait) {
     tx_header.DLC = AMPERES_MSG_DLC;
     tx_header.TransmitGlobalTime = DISABLE;
 
-    // Split data into uint8 elements
+    // Split data into uint8 elements; reference bps_pack_current_t struct
     // Little Endian: LSB at index 0
+    uint8_t tx_data[AMPERES_MSG_DLC] = {0};
+
+    /* Current Data: int32_t */
+    tx_data[0] = (uint8_t) (data->Main_Battery_Current & 0xFF);
+    tx_data[1] = (uint8_t) ((data->Main_Battery_Current >> 8) & 0xFF);
+    tx_data[2] = (uint8_t) ((data->Main_Battery_Current >> 16) & 0xFF);
 
     /* Raw ADC Value: uint16_t */
-    uint8_t tx_data[AMPERES_MSG_DLC] = {0};
-    tx_data[0] = (uint8_t) (data->adc_voltage & 0xFF);
-    tx_data[1] = (uint8_t) ((data->adc_voltage >> 8) & 0xFF);
-    
-    /* Current Data: int32_t */
-    tx_data[2] = (uint8_t) (data->current_data & 0xFF);
-    tx_data[3] = (uint8_t) ((data->current_data >> 8) & 0xFF);
-    tx_data[4] = (uint8_t) ((data->current_data >> 16) & 0xFF);
-    tx_data[5] = (uint8_t) ((data->current_data >> 24) & 0xFF);
-    
+    tx_data[3] = (uint8_t) (data->Main_Battery_Current_RawV & 0xFF);
+    tx_data[4] = (uint8_t) ((data->Main_Battery_Current_RawV >> 8) & 0xFF);
+
     // Send over CAN
     if (can_send(hcan1, &tx_header, tx_data, ticksToWait) != CAN_OK) {
         return AMPERES_CAN_SEND_FAIL;

--- a/Firmware/Drivers/Src/AmperesCAN.c
+++ b/Firmware/Drivers/Src/AmperesCAN.c
@@ -107,7 +107,7 @@ AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait
     tx_header.TransmitGlobalTime = DISABLE;
 
     // Convert ADC to voltage
-    uint16_t adc_to_voltage = ((uint32_t) data->Main_Battery_Current_RawV * 3300)/4095);
+    uint16_t adc_to_voltage = (((uint32_t) data->Main_Battery_Current_RawV * 3300)/4095);
 
     // Split data into uint8 elements; reference bps_pack_current_t struct
     // Little Endian: LSB at index 0

--- a/Firmware/Drivers/Src/AmperesCAN.c
+++ b/Firmware/Drivers/Src/AmperesCAN.c
@@ -109,8 +109,8 @@ AmperesStatus_t Amperes_SendCAN(bps_pack_current_t *data, TickType_t ticksToWait
     // Convert ADC to voltage
     uint16_t adc_to_voltage = (((uint32_t) data->Main_Battery_Current_RawV * 3300)/4095);
 
-    // Split data into uint8 elements; reference bps_pack_current_t struct
-    // Little Endian: LSB at index 0
+    // Pack data into fields: reference bps_pack_current_t struct
+    // Little Endian (LSB first): e.g. 0x123456 is stored as [56][34][12]
     uint8_t tx_data[AMPERES_MSG_DLC] = {0};
 
     /* Current Data: int32_t */

--- a/Firmware/Tasks/Inc/Tasks.h
+++ b/Firmware/Tasks/Inc/Tasks.h
@@ -43,7 +43,7 @@ extern StackType_t                  Task_Init_Stack[TASK_INIT_STACK_SIZE];
  * - ADC LPF cutoff frequency is ~100 Hz
  * - Sample at around 10 times that: 1000 Hz (1ms period)
  */
-#define AMPERES_TASK_PERIOD         pdMS_TO_TICKS(1)
+#define AMPERES_TASK_PERIOD_MS      1
 
 
 /** ================================================================

--- a/Firmware/Tasks/Src/Amperes_Task.c
+++ b/Firmware/Tasks/Src/Amperes_Task.c
@@ -6,8 +6,8 @@
 
 void Amperes_Task(void *pvParameters) {
     TickType_t xLastWakeTime = xTaskGetTickCount();
-    AmperesMsg_t message = {0};
-    AmperesMsg_t sum = {0};
+    bps_pack_current_t message = {0};
+    bps_pack_current_t sum = {0};
 
     uint8_t counter = 0;
     uint8_t conv_count = 0;
@@ -31,8 +31,8 @@ void Amperes_Task(void *pvParameters) {
         // Block until we receive data in queue
         if (Amperes_GetReading(&message, AMPERES_TASK_PERIOD) == AMPERES_OK) {
             conv_count++;
-            sum.adc_voltage += message.adc_voltage;
-            sum.current_data += message.current_data;
+            sum.Main_Battery_Current += message.Main_Battery_Current;
+            sum.Main_Battery_Current_RawV += message.Main_Battery_Current_RawV;
         } else {
             #if PRINTF_ENABLED
             printf("ADC Reading Error\r\n");
@@ -44,8 +44,8 @@ void Amperes_Task(void *pvParameters) {
         if (counter >= 10) {
             if (conv_count > 0) {
                 // Average data and send over CAN
-                message.adc_voltage = (sum.adc_voltage / conv_count);
-                message.current_data = (sum.current_data / conv_count);
+                message.Main_Battery_Current = (sum.Main_Battery_Current / conv_count);
+                message.Main_Battery_Current_RawV = (sum.Main_Battery_Current_RawV / conv_count);
 
                 // Send data over CAN
                 if (Amperes_SendCAN(&message, AMPERES_TASK_PERIOD) != AMPERES_OK) {
@@ -55,11 +55,11 @@ void Amperes_Task(void *pvParameters) {
                 }
 
                 #if PRINTF_ENABLED
-                printf("\r\n adc %d|i %li| conv %d \r\n", message.adc_voltage, message.current_data, conv_count);
+                printf("\r\n i %li| adc %d | conv %d \r\n", message.Main_Battery_Current, message.Main_Battery_Current_RawV, conv_count);
                 #endif
                 
                 // Reset variables
-                sum.adc_voltage = sum.current_data = 0;
+                sum.Main_Battery_Current = sum.Main_Battery_Current_RawV = 0;
                 counter = conv_count = 0;
             } else {
                 // Error: no adc conversions
@@ -69,7 +69,7 @@ void Amperes_Task(void *pvParameters) {
             }
             
             // Update LED values
-            if (message.current_data < 0) {
+            if (message.Main_Battery_Current < 0) {
                 // Negative means charging
                 HAL_GPIO_WritePin(AMPERES_GPIO_PORT, AMPERES_CHARGE_PIN, GPIO_PIN_SET);
                 HAL_GPIO_WritePin(AMPERES_GPIO_PORT, AMPERES_DISCHARGE_PIN, GPIO_PIN_RESET);

--- a/Firmware/Tasks/Src/Amperes_Task.c
+++ b/Firmware/Tasks/Src/Amperes_Task.c
@@ -4,13 +4,17 @@
     #define PRINTF_ENABLED 0
 #endif
 
+#define CAN_SEND_PERIOD_MS 100
+#define CAN_SEND_PERIOD_COUNT (CAN_SEND_PERIOD_MS / AMPERES_TASK_PERIOD_MS)
+
 void Amperes_Task(void *pvParameters) {
     TickType_t xLastWakeTime = xTaskGetTickCount();
     bps_pack_current_t message = {0};
-    bps_pack_current_t sum = {0};
+    int32_t current_sum = 0;
+    uint32_t adc_sum = 0;
 
-    uint8_t counter = 0;
-    uint8_t conv_count = 0;
+    uint8_t counter = 0;    // loop counter
+    uint8_t conv_count = 0; // adc conversion count
     // uint8_t adc_errors = 0;
     // uint8_t can_errors = 0;
 
@@ -29,10 +33,10 @@ void Amperes_Task(void *pvParameters) {
         }
 
         // Block until we receive data in queue
-        if (Amperes_GetReading(&message, AMPERES_TASK_PERIOD) == AMPERES_OK) {
+        if (Amperes_GetReading(&message, pdMS_TO_TICKS(AMPERES_TASK_PERIOD_MS)) == AMPERES_OK) {
             conv_count++;
-            sum.Main_Battery_Current += message.Main_Battery_Current;
-            sum.Main_Battery_Current_RawV += message.Main_Battery_Current_RawV;
+            current_sum += message.Main_Battery_Current;
+            adc_sum += message.Main_Battery_Current_RawV;
         } else {
             #if PRINTF_ENABLED
             printf("ADC Reading Error\r\n");
@@ -40,15 +44,15 @@ void Amperes_Task(void *pvParameters) {
         }
 
         /* =================== CAN =================== */
-        // Send CAN messages at 100 Hz
-        if (counter >= 10) {
+        // Send CAN messages at 10 Hz
+        if (counter >= CAN_SEND_PERIOD_COUNT) {
             if (conv_count > 0) {
                 // Average data and send over CAN
-                message.Main_Battery_Current = (sum.Main_Battery_Current / conv_count);
-                message.Main_Battery_Current_RawV = (sum.Main_Battery_Current_RawV / conv_count);
+                message.Main_Battery_Current = (current_sum / conv_count);
+                message.Main_Battery_Current_RawV = (uint16_t) (adc_sum / conv_count);
 
                 // Send data over CAN
-                if (Amperes_SendCAN(&message, AMPERES_TASK_PERIOD) != AMPERES_OK) {
+                if (Amperes_SendCAN(&message, pdMS_TO_TICKS(AMPERES_TASK_PERIOD_MS)) != AMPERES_OK) {
                     #if PRINTF_ENABLED
                     printf("CAN Send Error\r\n");
                     #endif
@@ -59,7 +63,7 @@ void Amperes_Task(void *pvParameters) {
                 #endif
                 
                 // Reset variables
-                sum.Main_Battery_Current = sum.Main_Battery_Current_RawV = 0;
+                current_sum = adc_sum = 0;
                 counter = conv_count = 0;
             } else {
                 // Error: no adc conversions
@@ -91,6 +95,6 @@ void Amperes_Task(void *pvParameters) {
 
         /* =================== Period Delay =================== */
         // Using vTaskDelayUntil allows us to set a constant time period.
-        vTaskDelayUntil(&xLastWakeTime, AMPERES_TASK_PERIOD); 
+        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(AMPERES_TASK_PERIOD_MS)); 
     }
 }

--- a/Firmware/Tasks/Src/MirrorCAN_Task.c
+++ b/Firmware/Tasks/Src/MirrorCAN_Task.c
@@ -20,9 +20,9 @@ void MirrorCAN_Task(void *pvParameters) {
         }
         
         // Print unpacked message
-        int32_t current = CURRENT_CONV(message.data);
-        uint16_t adc = ADC_CONV(message.data);
-        printf("\r\nValue:\tmA %5li | adc %04d \r\n", current, adc);
+        int32_t current_mA = AMPERES_UNPACK_CURRENT_mA(message.data);
+        uint16_t raw_mV = AMPERES_UNPACK_RAW_mV(message.data);
+        printf("\r\nValue:\tmA %5li | raw_mV %04d \r\n", current_mA, raw_mV);
 
         portYIELD();
     }

--- a/Firmware/Tasks/Src/MirrorCAN_Task.c
+++ b/Firmware/Tasks/Src/MirrorCAN_Task.c
@@ -1,8 +1,8 @@
 #include "Tasks.h"
 
-// Reconstruct Values
-#define CURRENT_CONV(x)    ( (int32_t) (x[5] << 24) | (int32_t) (x[4] << 16) | (int32_t) (x[3] << 8) | (int32_t) x[2] )
-#define ADC_CONV(x)        ( (uint16_t)((x[1] << 8) | (uint16_t) x[0]) )
+// Reconstruct Values: little endian, see bps_pack_current_t struct
+#define CURRENT_CONV(x)    ( (int32_t) (x[2] << 16) | (int32_t) (x[1] << 8) | (int32_t) x[0] )
+#define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
 
 void can_tx_callback_hook(CAN_HandleTypeDef* hcan, const can_tx_payload_t* payload) {
     BaseType_t higherPriorityTaskWoken = pdFALSE;
@@ -26,7 +26,7 @@ void MirrorCAN_Task(void *pvParameters) {
         // Print unpacked message
         int32_t current = CURRENT_CONV(message.data);
         uint16_t adc = ADC_CONV(message.data);
-        printf("\r\nValue:\tadc %04d | mA %5li \r\n", adc, current);
+        printf("\r\nValue:\tmA %5li | adc %04d \r\n", current, adc);
 
         portYIELD();
     }

--- a/Firmware/Tasks/Src/MirrorCAN_Task.c
+++ b/Firmware/Tasks/Src/MirrorCAN_Task.c
@@ -1,9 +1,5 @@
 #include "Tasks.h"
 
-// Reconstruct Values: little endian, see bps_pack_current_t struct. handle sign extension for 24b -> int32_t
-#define CURRENT_CONV(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
-#define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
-
 void can_tx_callback_hook(CAN_HandleTypeDef* hcan, const can_tx_payload_t* payload) {
     BaseType_t higherPriorityTaskWoken = pdFALSE;
     HAL_GPIO_TogglePin(AMPERES_GPIO_PORT, AMPERES_HB_PIN);

--- a/Firmware/Tasks/Src/MirrorCAN_Task.c
+++ b/Firmware/Tasks/Src/MirrorCAN_Task.c
@@ -1,7 +1,7 @@
 #include "Tasks.h"
 
-// Reconstruct Values: little endian, see bps_pack_current_t struct
-#define CURRENT_CONV(x)    ( (int32_t) (x[2] << 16) | (int32_t) (x[1] << 8) | (int32_t) x[0] )
+// Reconstruct Values: little endian, see bps_pack_current_t struct. handle sign extension for 24b -> int32_t
+#define CURRENT_CONV(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
 #define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
 
 void can_tx_callback_hook(CAN_HandleTypeDef* hcan, const can_tx_payload_t* payload) {

--- a/Firmware/Tests/test_adc.c
+++ b/Firmware/Tests/test_adc.c
@@ -12,9 +12,9 @@ StaticTask_t xADCTaskBuffer;
 StackType_t xADCStack[ 200 ];
 
 void ADC_Task(void *pvParameters) {
-    AmperesMsg_t message = {
-        .adc_voltage = 0,
-        .current_data = 0
+    bps_pack_current_t message = {
+        .Main_Battery_Current = 0,
+        .Main_Battery_Current_RawV = 0
     };
     TickType_t xLastWakeTime = xTaskGetTickCount();
 
@@ -30,8 +30,8 @@ void ADC_Task(void *pvParameters) {
         }
 
         // Debug
-        printf("\r\n ADC: %4d, CURRENT: %5li \r\n", message.adc_voltage, message.current_data);
-        if (message.current_data < 0) {
+        printf("\r\n CURRENT: %5li, ADC: %4d \r\n", message.Main_Battery_Current, message.Main_Battery_Current_RawV);
+        if (message.Main_Battery_Current < 0) {
             // Negative means charging
             HAL_GPIO_WritePin(AMPERES_GPIO_PORT, AMPERES_CHARGE_PIN, GPIO_PIN_SET);
             HAL_GPIO_WritePin(AMPERES_GPIO_PORT, AMPERES_DISCHARGE_PIN, GPIO_PIN_RESET);

--- a/Firmware/Tests/test_calibration.c
+++ b/Firmware/Tests/test_calibration.c
@@ -17,7 +17,7 @@ StackType_t xADCStack[ 200 ];
  * Measure 100 ADC readings at known currents and outputs to console.
  */
 void ADC_Task(void *pvParameters) {
-    AmperesMsg_t message = {0};
+    bps_pack_current_t message = {0};
     uint32_t adc_sum = 0;
     int64_t current_sum = 0;
     TickType_t xLastWakeTime = xTaskGetTickCount();
@@ -39,10 +39,10 @@ void ADC_Task(void *pvParameters) {
         }
 
         // Sum
-        adc_sum += message.adc_voltage;
-        current_sum += message.current_data;
-
-        // printf("\r\n ADC: %4d, CURRENT: %5li \r\n", message.adc_voltage, message.current_data);
+        current_sum += message.Main_Battery_Current;
+        adc_sum += message.Main_Battery_Current_RawV;
+        
+        // printf("\r\n CURRENT: %5li, ADC: %4d \r\n", message.Main_Battery_Current, message.Main_Battery_Current_RawV);
         vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(1));
     }
     // Print result

--- a/Firmware/Tests/test_can_loopback.c
+++ b/Firmware/Tests/test_can_loopback.c
@@ -10,8 +10,8 @@
  * !!! CAN mode must be set to LOOPBACK and filter must accept ID
  * ================================================================ */
 
-// Reconstruct Values: little endian, see bps_pack_current_t struct
-#define CURRENT_CONV(x)    ( (int32_t) (x[2] << 16) | (int32_t) (x[1] << 8) | (int32_t) x[0] )
+// Reconstruct Values: little endian, see bps_pack_current_t struct. handle sign extension for 24b -> int32_t
+#define CURRENT_CONV(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
 #define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
 
 StaticTask_t xTaskBuffer;

--- a/Firmware/Tests/test_can_loopback.c
+++ b/Firmware/Tests/test_can_loopback.c
@@ -10,9 +10,9 @@
  * !!! CAN mode must be set to LOOPBACK and filter must accept ID
  * ================================================================ */
 
-// Reconstruct Values
-#define CURRENT_CONV    ( (int32_t) (rx_data[5] << 24) | (int32_t) (rx_data[4] << 16) | (int32_t) (rx_data[3] << 8) | (int32_t) rx_data[2] )
-#define ADC_CONV        ( (uint16_t)((rx_data[1] << 8) | (uint16_t) rx_data[0]) )
+// Reconstruct Values: little endian, see bps_pack_current_t struct
+#define CURRENT_CONV(x)    ( (int32_t) (x[2] << 16) | (int32_t) (x[1] << 8) | (int32_t) x[0] )
+#define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
 
 StaticTask_t xTaskBuffer;
 StackType_t xStack[200];
@@ -20,28 +20,28 @@ StackType_t xStack[200];
 void Task_CAN_Loopback() {
     // Receive
     CAN_RxHeaderTypeDef rx_header = {0};
-    uint8_t rx_data[6] = {0};
+    uint8_t rx_data[AMPERES_MSG_DLC] = {0};
     can_status_t status;
     uint16_t adc;
     int32_t current;
 
     // Transmit
-    AmperesMsg_t payload = {
-        .adc_voltage = 4095,
-        .current_data = 80000
+    bps_pack_current_t payload = {
+        .Main_Battery_Current = 80000,
+        .Main_Battery_Current_RawV = 4095        
     };
     
     while (1) {
         // Increment data
-        if (payload.adc_voltage < 15) {
-            payload.adc_voltage = 4095;
+        if (payload.Main_Battery_Current == -30000) {
+            payload.Main_Battery_Current = 80000;
         } else {
-            payload.adc_voltage -= 15;
+            payload.Main_Battery_Current -= 1000;
         }
-        if (payload.current_data == -30000) {
-            payload.current_data = 80000;
+        if (payload.Main_Battery_Current_RawV < 15) {
+            payload.Main_Battery_Current_RawV = 4095;
         } else {
-            payload.current_data -= 1000;
+            payload.Main_Battery_Current_RawV -= 15;
         }
 
         // Send CAN data
@@ -49,7 +49,7 @@ void Task_CAN_Loopback() {
             printf("no can send \r\n");
             Error_Handler();
         }
-        printf("\r\nSEND \t adc %4d | current %5li \r\n", payload.adc_voltage, payload.current_data);
+        printf("\r\nSEND \t current %5li | adc %4d \r\n", payload.Main_Battery_Current, payload.Main_Battery_Current_RawV);
 
         // Receive payload; make sure CAN filter in Amperes_CAN_Init will accept this ID
         status = can_recv(hcan1, AMPERES_MSG_ID, &rx_header, rx_data, portMAX_DELAY);
@@ -63,10 +63,10 @@ void Task_CAN_Loopback() {
         }
 
         // Convert back hopefully
-        adc = ADC_CONV;
-        current = CURRENT_CONV;
-        printf("RECV \t adc %4d | current %5li \r\n", adc, current);
-        if ((adc != payload.adc_voltage) || (current != payload.current_data)) {
+        current = CURRENT_CONV(rx_data);
+        adc = ADC_CONV(rx_data);
+        printf("RECV \t current %5li | adc %4d \r\n", current, adc);
+        if ((current != payload.Main_Battery_Current) || (adc != payload.Main_Battery_Current_RawV)) {
             Error_Handler();
         }
         printf("Match! \r\n");
@@ -83,7 +83,7 @@ int main() {
     SystemClock_Config();
     UART_Printf_Init();
 
-    // Make sure CAN is set to loopback
+    // Make sure CAN is set to loopback; makefile should handle this
     MX_GPIO_Init();
     if (Amperes_CAN_Init() != AMPERES_OK) Error_Handler();
     if (Amperes_CAN_Start() != AMPERES_OK) Error_Handler();

--- a/Firmware/Tests/test_can_loopback.c
+++ b/Firmware/Tests/test_can_loopback.c
@@ -10,10 +10,6 @@
  * !!! CAN mode must be set to LOOPBACK and filter must accept ID
  * ================================================================ */
 
-// Reconstruct Values: little endian, see bps_pack_current_t struct. handle sign extension for 24b -> int32_t
-#define CURRENT_CONV(x)    ( (int32_t)(((uint32_t)(x)[2] << 24) | ((uint32_t)(x)[1] << 16) | ((uint32_t)(x)[0] << 8)) >> 8 )
-#define ADC_CONV(x)        ( (uint16_t)((x[4] << 8) | (uint16_t) x[3]) )
-
 StaticTask_t xTaskBuffer;
 StackType_t xStack[200];
 

--- a/Firmware/Tests/test_can_loopback.c
+++ b/Firmware/Tests/test_can_loopback.c
@@ -18,8 +18,8 @@ void Task_CAN_Loopback() {
     CAN_RxHeaderTypeDef rx_header = {0};
     uint8_t rx_data[AMPERES_MSG_DLC] = {0};
     can_status_t status;
-    uint16_t adc;
-    int32_t current;
+    int32_t current_mA;
+    uint16_t raw_mV;
 
     // Transmit
     bps_pack_current_t payload = {
@@ -59,10 +59,10 @@ void Task_CAN_Loopback() {
         }
 
         // Convert back hopefully
-        current = CURRENT_CONV(rx_data);
-        adc = ADC_CONV(rx_data);
-        printf("RECV \t current %5li | adc %4d \r\n", current, adc);
-        if ((current != payload.Main_Battery_Current) || (adc != payload.Main_Battery_Current_RawV)) {
+        current_mA = AMPERES_UNPACK_CURRENT_mA(rx_data);
+        raw_mV = AMPERES_UNPACK_RAW_mV(rx_data);
+        printf("RECV \t current %5li | raw_mV %4d \r\n", current_mA, raw_mV);
+        if ((current_mA != payload.Main_Battery_Current) || (raw_mV != payload.Main_Battery_Current_RawV)) {
             Error_Handler();
         }
         printf("Match! \r\n");

--- a/Firmware/Tests/test_mirror_can.c
+++ b/Firmware/Tests/test_mirror_can.c
@@ -17,7 +17,7 @@ void Queue_Send() {
             .DLC = AMPERES_MSG_DLC,
             .TransmitGlobalTime = DISABLE
         },
-        .data = {0, 1, 2, 3, 4, 5}
+        .data = {0, 1, 2, 3, 4}
     };
     
     while (1) {
@@ -28,9 +28,9 @@ void Queue_Send() {
 }
 
 void CAN_Send() {
-    AmperesMsg_t message = {
-        .adc_voltage = 20,
-        .current_data = -1000
+    bps_pack_current_t message = {
+        .Main_Battery_Current = -1000,
+        .Main_Battery_Current_RawV = 20
     };
     
     while (1) {


### PR DESCRIPTION
- Corrected CAN message fields
- Now sending ADC voltage instead of counts